### PR TITLE
Small-ish Update

### DIFF
--- a/GitWorktreeManager/Behaviors/DialogHelper.cs
+++ b/GitWorktreeManager/Behaviors/DialogHelper.cs
@@ -39,25 +39,17 @@ internal static class DialogHelper
         await dialog.ShowAsync();
     }
 
-    public static async Task<string> ShowNewBranchDialogAsync(string baseBranch)
+    public static async Task<string?> ShowNewBranchDialogAsync(string baseBranch)
     {
-        var content = new NewBranchDialogContent 
+        var dialog = new NewBranchContentDialog(baseBranch);
+
+        if (await dialog.ShowAsync() is ContentDialogResult.Primary)
         {
-            BaseBranchName = $"Based on '{baseBranch}'"
-        };
-
-        var dialog = new ContentDialog
+            return dialog.NewBranch;
+        }
+        else
         {
-            // XamlRoot must be set in the case of a ContentDialog running in a Desktop app
-            XamlRoot = MainWindow.Instance.Content.XamlRoot,
-
-            Title = "New branch",
-            Content = content,
-            CloseButtonText = "Ok"
-        };
-
-        await dialog.ShowAsync();
-
-        return content.BranchName;
+            return null;
+        }
     }
 }

--- a/GitWorktreeManager/Behaviors/NewBranchContentDialog.cs
+++ b/GitWorktreeManager/Behaviors/NewBranchContentDialog.cs
@@ -1,0 +1,58 @@
+﻿namespace GitWorktreeManager.Behaviors;
+
+using Microsoft.UI.Xaml.Controls;
+using System;
+using System.Threading.Tasks;
+using Windows.System;
+
+public class NewBranchContentDialog : ContentDialog
+{
+    private readonly NewBranchDialogContent content;
+
+    private ContentDialogResult result;
+
+    public string? NewBranch => this.content.BranchName;
+
+    public NewBranchContentDialog(string baseBranch)
+    {
+        // XamlRoot must be set in the case of a ContentDialog running in a Desktop app
+        XamlRoot = MainWindow.Instance.Content.XamlRoot;
+
+        this.content = new NewBranchDialogContent
+        {
+            BaseBranchName = $"Based on '{baseBranch}'"
+        };
+
+        Title = "New branch";
+        Content = content;
+        PrimaryButtonText = "Ok";
+        SecondaryButtonText = "Cancel";
+
+        content.CloseKeyPressed += key =>
+        {
+            if (key is VirtualKey.Enter)
+            {
+                this.result = ContentDialogResult.Primary;
+                this.Hide(); // Will cause the base.ShowAsync() call to return with ContentDialogResult.None
+            }
+            else if (key is VirtualKey.Escape)
+            {
+                this.result = ContentDialogResult.Secondary;
+                this.Hide(); // Will cause the base.ShowAsync() call to return with ContentDialogResult.None
+            }
+        };
+    }
+
+    public new async Task<ContentDialogResult> ShowAsync()
+    {
+        var baseResult = await base.ShowAsync();
+        if (baseResult is not ContentDialogResult.None)
+        {
+            return baseResult;
+        }
+        else
+        {
+            return this.result;
+        }
+    }
+}

--- a/GitWorktreeManager/MainView.xaml
+++ b/GitWorktreeManager/MainView.xaml
@@ -190,7 +190,7 @@
 
             <Image Grid.Column="0" Height="25" VerticalAlignment="Center" Margin="10, 10, 10, 10" Source="ms-appx:///Assets/StoreAppList.png" />
 
-            <TextBlock x:Name="AppTitle" Grid.Column="1" Text="Branch Manager" VerticalAlignment="Center" />
+            <TextBlock x:Name="AppTitle" Grid.Column="1" Text="{x:Bind VM.Repo.RepoInfo.Name, Mode=OneWay, FallbackValue='Branch Manager'}" VerticalAlignment="Center" />
         </Grid>
 
         <Grid Grid.Row="1" Margin="5, 0, 5, 5">

--- a/GitWorktreeManager/MainView.xaml
+++ b/GitWorktreeManager/MainView.xaml
@@ -200,7 +200,9 @@
                 <ColumnDefinition Width="Auto" />
             </Grid.ColumnDefinitions>
 
-            <TextBox Text="{x:Bind VM.Repo.RepoInfo.Name, Mode=OneWay}" PlaceholderText="Repo" IsEnabled="False" Margin="5, 0" />
+            <TextBox Name="BranchName" PlaceholderText="Find branch" Margin="5, 0"
+                     IsEnabled="{x:Bind VM.Repo, Mode=OneWay, Converter={StaticResource NullToBoolConverter}}"
+                     behaviors:TextChangedCommandBehavior.TextChangedCommand="{x:Bind VM.Repo.QueryChangedCommand, Mode=OneWay}" />
 
             <Button Grid.Column="1" Command="{x:Bind VM.OpenRepoCommand}" ToolTipService.ToolTip="Open git repo" Margin="5, 0">
                 <SymbolIcon Symbol="OpenLocal" />
@@ -221,17 +223,7 @@
             <ContentControl.ContentTemplate>
                 <DataTemplate x:DataType="vm:RepoViewModel">
                     <Grid>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition />
-                        </Grid.RowDefinitions>
-
-                        <Grid Grid.Row="0" Margin="5">
-                            <TextBox Name="BranchName" PlaceholderText="Find branch" Margin="5, 0"
-                                     behaviors:TextChangedCommandBehavior.TextChangedCommand="{x:Bind QueryChangedCommand}" />
-                        </Grid>
-
-                        <ListView Grid.Row="1" Margin="-10, 5, -10, 0"
+                        <ListView Margin="-10, 5, -10, 0"
                                   ItemsSource="{x:Bind FilteredBranches, Mode=OneWay}" 
                                   ItemTemplateSelector="{StaticResource BranchTemplateSelector}">
                             <ListView.ItemContainerStyle>

--- a/GitWorktreeManager/NewBranchDialogContent.xaml
+++ b/GitWorktreeManager/NewBranchDialogContent.xaml
@@ -10,7 +10,7 @@
     <Grid>
         <StackPanel>
             <TextBlock Text="{x:Bind BaseBranchName}" />
-            <TextBox Text="{x:Bind BranchName, Mode=TwoWay}" Margin="0, 10" />
+            <TextBox Text="{x:Bind BranchName, Mode=TwoWay}" KeyUp="OnKeyUp" Margin="0, 10" />
         </StackPanel>
     </Grid>
 </UserControl>

--- a/GitWorktreeManager/NewBranchDialogContent.xaml.cs
+++ b/GitWorktreeManager/NewBranchDialogContent.xaml.cs
@@ -1,6 +1,8 @@
 namespace GitWorktreeManager;
 
 using Microsoft.UI.Xaml.Controls;
+using System;
+using Windows.System;
 
 public sealed partial class NewBranchDialogContent : UserControl
 {
@@ -8,8 +10,18 @@ public sealed partial class NewBranchDialogContent : UserControl
     
     public string BranchName { get; set; }
 
+    public event Action<VirtualKey> CloseKeyPressed;
+
     public NewBranchDialogContent()
     {
         this.InitializeComponent();
+    }
+
+    private void OnKeyUp(object sender, Microsoft.UI.Xaml.Input.KeyRoutedEventArgs e)
+    {
+        if (e.Key is VirtualKey.Enter or VirtualKey.Escape)
+        {
+            this.CloseKeyPressed(e.Key);
+        }
     }
 }

--- a/GitWorktreeManager/ViewModel/RepoViewModel.cs
+++ b/GitWorktreeManager/ViewModel/RepoViewModel.cs
@@ -14,8 +14,8 @@ using Windows.System;
 
 public class RepoInfo
 {
-    public string Name { get; init; }
-    public string Path { get; init; }
+    public required string Name { get; init; }
+    public required string Path { get; init; }
 }
 
 [INotifyPropertyChanged]
@@ -35,6 +35,8 @@ public partial class RepoViewModel
             Path = path,
             Name = name
         };
+
+        MainWindow.Instance.Title = name;
 
         this.gitClient = new GitApi(path);
     }
@@ -201,7 +203,7 @@ public partial class RepoViewModel
 
             if (string.IsNullOrWhiteSpace(newBranchName))
             {
-                throw new ArgumentException("Branch name should not be empty.");
+                return;
             }
 
             if (vm is RemoteBranchWithoutWorktree)


### PR DESCRIPTION
Bug Fixes:
- Opening a worktree in VS Code now works properly

UX Imprevements:
- Create new branch dialog now has Cancel button and works with Enter and Esc keys
- The repo name is now written in the app's title
  - It makes "shell discoverability" better on the Taskbar and on Win+Tab view
  - It also made the header a bit thinner, giving even more space to list worktrees/branches